### PR TITLE
Chore: Create setupViewModel method in TableViewController

### DIFF
--- a/ONECore/Classes/ViewControllers/TableViewController/TableViewController.swift
+++ b/ONECore/Classes/ViewControllers/TableViewController/TableViewController.swift
@@ -32,6 +32,7 @@ open class TableViewController: ViewController, TableViewContainerProtocol {
     open var tableViewBackgroundColor: UIColor { return CoreStyle.Color.primaryBackground }
     open var tableViewInset: UIEdgeInsets { return UIEdgeInsets.zero }
     open func registerNibs() {}
+    open func setupViewModel() {}
 
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -114,6 +115,7 @@ open class TableViewController: ViewController, TableViewContainerProtocol {
 
     open func render() {
         if contentView == nil { return }
+        setupViewModel()
         contentView.removeAllSection()
         sectionCollection.configure(contentView: contentView)
     }


### PR DESCRIPTION
# JIRA Ticket Link:
None.

# Issue
- Create `setupViewModel` method called at the beginning of the `render` method.
- `setupViewModel` is the place for ViewController to setup their **Child View** view model.

# Solution
None.

# Documentation/References (if any)
None.

# Dependencies (if any)
None.

# Screenshots (if appropriate)
None.

# Other things that are not related to the JIRA ticket (if any)
None.

# To Do (if WIP)
* [ ] None
* [X] None
