### PR TITLE
Fix: Time Picker double input

### DIFF
--- a/ONECore/Classes/Views/TextField/Types/TimePickerInputType.swift
+++ b/ONECore/Classes/Views/TextField/Types/TimePickerInputType.swift
@@ -53,8 +53,6 @@ open class TimePickerInputType: InputType {
     @objc private func close() {
         textField.resignFirstResponder()
         overlay.isHidden = true
-        guard let didChangeAction = textField.didChangeAction else { return }
-        didChangeAction(textField, datePicker.date)
     }
 
     @objc private func done() {


### PR DESCRIPTION
# JIRA Ticket Link:
None.

# Issue
- didChangeinput called multiple times

# Solution
- remove didChange in close()

# Documentation/References (if any)
None.

# Dependencies (if any)
None.

# Screenshots (if appropriate)
None.

# Other things that are not related to the JIRA ticket (if any)
- Please check in prospeku

# To Do (if WIP)
* [ ] None
* [X] None
