### PR TITLE
add default date type wheels

### DIFF
--- a/ONECore/Classes/Views/TextField/Types/DatePickerInputType.swift
+++ b/ONECore/Classes/Views/TextField/Types/DatePickerInputType.swift
@@ -45,6 +45,9 @@ open class DatePickerInputType: InputType {
         datePicker.minimumDate = minimumDate
         datePicker.maximumDate = maximumDate
         datePicker.datePickerMode = .date
+        if #available(iOS 13.4, *) {
+            datePicker.preferredDatePickerStyle = .wheels
+        }
     }
 
     private func applyStyle() {


### PR DESCRIPTION
# JIRA Ticket Link:
None.

# Issue
- date with format full (dd mm yyyy) picker defaulted into compact in OS14. (but the variable alr on iOS with OS 13.4+) , the requirement is to display wheel like onecore used to.

# Solution
- add prefered style wheel. so it will display like it used to

# Documentation/References (if any)
- https://developer.apple.com/documentation/uikit/uidatepicker/3526124-preferreddatepickerstyle

# Dependencies (if any)
None.

# Screenshots (if appropriate)
None.

# Other things that are not related to the JIRA ticket (if any)
None.

