### PR TITLE
add capability to shrink text if the framesize not fit.

### DIFF
--- a/ONECore/Classes/Views/CheckboxView/CheckboxView.swift
+++ b/ONECore/Classes/Views/CheckboxView/CheckboxView.swift
@@ -108,6 +108,8 @@ open class CheckboxView: UIView {
         textLabel.contentMode = .topLeft
         textLabel.translatesAutoresizingMaskIntoConstraints = false
         textLabel.numberOfLines = 0
+        textLabel.adjustsFontSizeToFitWidth = true
+        textLabel.minimumScaleFactor = 0.5
         addSubview(textLabel)
         createTextLabelHorizontalConstraint()
         createTextLabelVerticalConstraint()


### PR DESCRIPTION
# JIRA Ticket Link:
None.

# Issue
- textField clipped if the framesize smaller then rendered text.

# Solution
- add ability to shrink

# Documentation/References (if any)
None.

# Dependencies (if any)
None.

# Screenshots (if appropriate)
None.

# Other things that are not related to the JIRA ticket (if any)
None.
