### PR TITLE
Fix: ios 15 table view section header top padding

### DIFF
--- a/ONECore/Classes/ViewControllers/TableViewController/TableViewController.swift
+++ b/ONECore/Classes/ViewControllers/TableViewController/TableViewController.swift
@@ -106,10 +106,7 @@ open class TableViewController: ViewController, TableViewContainerProtocol {
         )
         renderRefreshControl()
         view.addSubview(contentView)
-        configureBackgroundColor()
-        if #available(iOS 15.0, *) {
-            contentView.tableView.sectionHeaderTopPadding = DefaultValue.emptyCGFloat
-        }
+        configureBackgroundColor()     
     }
 
     open func resetCellSelection() {

--- a/ONECore/Classes/ViewControllers/TableViewController/TableViewController.swift
+++ b/ONECore/Classes/ViewControllers/TableViewController/TableViewController.swift
@@ -107,6 +107,9 @@ open class TableViewController: ViewController, TableViewContainerProtocol {
         renderRefreshControl()
         view.addSubview(contentView)
         configureBackgroundColor()
+        if #available(iOS 15.0, *) {
+            contentView.tableView.sectionHeaderTopPadding = DefaultValue.emptyCGFloat
+        }
     }
 
     open func resetCellSelection() {

--- a/ONECore/Classes/ViewControllers/TableViewController/TableViewController.swift
+++ b/ONECore/Classes/ViewControllers/TableViewController/TableViewController.swift
@@ -106,7 +106,7 @@ open class TableViewController: ViewController, TableViewContainerProtocol {
         )
         renderRefreshControl()
         view.addSubview(contentView)
-        configureBackgroundColor()     
+        configureBackgroundColor()
     }
 
     open func resetCellSelection() {

--- a/ONECore/Classes/Views/TableView/TableView.swift
+++ b/ONECore/Classes/Views/TableView/TableView.swift
@@ -102,6 +102,9 @@ open class TableView: View {
         if #available(iOS 9.0, *) {
             tableView.cellLayoutMarginsFollowReadableWidth = false
         }
+        if #available(iOS 15.0, *) {
+            tableView.sectionHeaderTopPadding = DefaultValue.emptyCGFloat
+        }
     }
 
     open func setTableViewSeparator(


### PR DESCRIPTION
# JIRA Ticket Link:
https://jira.ocbcnisp.co.id/browse/OMBYON-4493

# Issue
new ios 15 feature, add section top padding to tableview that cause most of the section top has padding

# Solution
set default tableview section top padding to 0

# Documentation/References (if any)
None.

# Dependencies (if any)
None.

# Screenshots (if appropriate)

before
![Simulator Screen Shot - iPhone 8 - 2021-10-21 at 11 14 23](https://user-images.githubusercontent.com/20590558/138212955-35013cb7-a748-44ab-b08f-5df695e1f94f.png)

![Simulator Screen Shot - iPhone 8 - 2021-10-21 at 11 14 16](https://user-images.githubusercontent.com/20590558/138212981-7e2cd6d0-843c-4998-addf-4dd0ebf44361.png)


after
![Simulator Screen Shot - iPhone 8 - 2021-10-21 at 11 10 01](https://user-images.githubusercontent.com/20590558/138213040-c3037b81-41e1-475d-8844-b48241347a23.png)
![Simulator Screen Shot - iPhone 8 - 2021-10-21 at 11 10 09](https://user-images.githubusercontent.com/20590558/138213047-9a0e07a7-53d1-479a-887a-f0baede346f1.png)
![Simulator Screen Shot - iPhone 8 - 2021-10-21 at 11 10 15](https://user-images.githubusercontent.com/20590558/138213050-37a8aa92-5811-4fea-bc1a-4c4b7e56d0ad.png)


# Other things that are not related to the JIRA ticket (if any)
None.

# To Do (if WIP)
* [ ] None
* [X] None
